### PR TITLE
Add link-summoner integration to enable live previews for markets in docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,6 +48,13 @@ const config = {
     },
   ],
 
+  scripts: [
+    {
+      src: 'https://cdn.jsdelivr.net/npm/link-summoner@1.0.2/dist/browser.min.js',
+      async: 'true'
+    }
+  ],
+
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({


### PR DESCRIPTION
Adds preview for market links and some other whitelisted set of links (e.g. wikipedia, lesswrong, etc)

I've discussed this previously with @akrolsmir 

![manifold-docs-link-summoner](https://user-images.githubusercontent.com/81347/167044694-7cb764ce-4992-44a6-aa71-3bf869ca77ee.gif)

Link summoner: https://github.com/Stvad/link-summoner