### PR TITLE
Remove emphasis in equation

### DIFF
--- a/docs/binary-markets.md
+++ b/docs/binary-markets.md
@@ -20,8 +20,8 @@
     - Our fee schedule is currently: 13% * (1 - post-bet probability) * bet amount
         - The post-trade probability is what the market probability would be after your bet if there were no fees.
         - Example:
-            - If you bet $100 on NO and the resulting probability without fees would be 10%, then you pay $100 * 13% * 10% = $1.3.
-            - If you bet $100 on YES and the resulting probability without fees would be 90%, then you pay $100 * 13% * 10% = $1.3.
+            - If you bet $100 on NO and the resulting probability without fees would be 10%, then you pay `$100 * 13% * 10% = $1.3`.
+            - If you bet $100 on YES and the resulting probability without fees would be 90%, then you pay `$100 * 13% * 10% = $1.3`.
         - The fees are used to provide a commission to the market creator and to subsidize trading within the market.
         - The market creator’s commission is paid out only after the market is resolved.
     - No fees are levied on sales.


### PR DESCRIPTION
In https://docs.manifold.markets/binary-markets, the sentence
> `$100 * 13% * 10% = $1.3`

is interpreted as 
> $100 13% 10% = $1.3

with 13% in italic. Because the `*` are symbols indicating start/end of italic. I don't know what system you use, so this suggest what I expect to be the safest correction, indicating as code, which ensure it won't be interpreted. If you have mathjax installed, using \($100 \times 13% \times 10% = $1.3\) maybe even better. With the downside that Github may not be able to interpret your page as it's not markdown anymore. (not sure about it; I have seen recent news about mathjax in github, but I didn't investigate a lot actually)